### PR TITLE
Converted main scene name to lowercase to match on-disk name

### DIFF
--- a/scenes/ui/loading_screen.gd
+++ b/scenes/ui/loading_screen.gd
@@ -4,7 +4,7 @@ extends Node
 @onready var loading_label = %LoadingLabel
 @onready var loading_sprite = %LoadingSprite
 
-var main_scene_path = "res://Scenes/main.tscn"
+var main_scene_path = "res://scenes/main.tscn"
 var loading_progress = []
 var scene_load_status = 0
 var main_scene: PackedScene


### PR DESCRIPTION
My first PR ever, just something simple. Yell if i've messed up.

On Linux the difference in case between the on-disk folder name and the path given causes the main scene to be not found and the loading scene stays forever.

I've simply changed the path to the main scene to lowercase to match.

Thanks for this template, I'm keen to try it out.