### PR TITLE
Create a Settings file that persists across user session

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,7 @@ config/icon="res://icon.svg"
 [autoload]
 
 MusicPlayer="*res://scenes/autoload/music_player.tscn"
+GameSettings="*res://scripts/game_settings.gd"
 
 [display]
 

--- a/resources/settings/settings.gd
+++ b/resources/settings/settings.gd
@@ -1,0 +1,18 @@
+extends Resource
+class_name Settings
+
+@export var sfx_volume: float = 1.0
+@export var music_volume: float = 1.0
+@export var window_mode: DisplayServer.WindowMode = DisplayServer.WINDOW_MODE_WINDOWED
+
+
+func set_window_mode(mode: DisplayServer.WindowMode):
+	window_mode = mode
+
+
+func set_bus_volume_percent(bus_name: String, percent: float):
+	match bus_name:
+		"Music":
+			music_volume = percent
+		"SFX":
+			sfx_volume = percent

--- a/resources/settings/settings.tres
+++ b/resources/settings/settings.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" script_class="Settings" load_steps=2 format=3 uid="uid://c1ldof8qqci2g"]
+
+[ext_resource type="Script" path="res://resources/settings/settings.gd" id="1_mloi4"]
+
+[resource]
+script = ExtResource("1_mloi4")
+sfx_volume = 1.0
+music_volume = 1.0
+window_mode = 0

--- a/scenes/autoload/music_player.tscn
+++ b/scenes/autoload/music_player.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3 uid="uid://75cxk0b01fjj"]
 
-[ext_resource type="AudioStream" uid="uid://dn76fcaxwv1ir" path="res://assets/audio/beach-waves.mp3" id="1_nvqnw"]
+[ext_resource type="AudioStream" uid="uid://05sufitseb2b" path="res://assets/audio/beach-waves.mp3" id="1_nvqnw"]
 [ext_resource type="Script" path="res://scenes/autoload/music_player.gd" id="2_5m715"]
 
 [node name="MusicPlayer" type="AudioStreamPlayer"]

--- a/scenes/ui/options_menu.gd
+++ b/scenes/ui/options_menu.gd
@@ -15,6 +15,7 @@ func _ready():
 	window_button.pressed.connect(on_window_button_pressed)
 	sfx_slider.value_changed.connect(on_audio_slider_changed.bind("SFX"))
 	music_slider.value_changed.connect(on_audio_slider_changed.bind("Music"))
+	
 	update_display()
 
 
@@ -36,16 +37,17 @@ func set_bus_volume_percent(bus_name: String, percent: float):
 	var bus_index = AudioServer.get_bus_index(bus_name)
 	var volume_db = linear_to_db(percent)
 	AudioServer.set_bus_volume_db(bus_index, volume_db)
+	GameSettings.write_back_volume_setting(bus_name, percent)
 
 
 func on_window_button_pressed():
 	var mode = DisplayServer.window_get_mode()
-	if mode != DisplayServer.WINDOW_MODE_FULLSCREEN:
-		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
+	if (mode == DisplayServer.WINDOW_MODE_FULLSCREEN):
+		GameSettings.set_window_mode(DisplayServer.WINDOW_MODE_WINDOWED)
 	else:
-		DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_BORDERLESS, false)
-		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
-	
+		GameSettings.set_window_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
+		
+	GameSettings.write_back_display_settings(DisplayServer.window_get_mode())
 	update_display()
 
 

--- a/scripts/game_settings.gd
+++ b/scripts/game_settings.gd
@@ -1,0 +1,47 @@
+extends Node
+
+var SETTINGS_FILE_PATH = "user://settings.tres"
+
+@export var settings = ResourceLoader.load("res://resources/settings/settings.tres")
+
+
+func _ready():
+	load_settings_file()
+	set_audio_bus("Music", settings.music_volume)
+	set_audio_bus("SFX", settings.sfx_volume)
+	set_window_mode(settings.window_mode)
+
+
+func load_settings_file():
+	if (ResourceLoader.exists(SETTINGS_FILE_PATH)):
+		settings = ResourceLoader.load(SETTINGS_FILE_PATH)
+
+
+func write_settings():
+	ResourceSaver.save(settings, SETTINGS_FILE_PATH)
+
+
+func set_audio_bus(bus_name: String, percent: float):
+	var bus_index = AudioServer.get_bus_index(bus_name)
+	var volume_db = linear_to_db(percent)
+	AudioServer.set_bus_volume_db(bus_index, volume_db)
+
+
+# This is a simple toggle between Fullscreen and Windowed Mode
+# https://docs.godotengine.org/en/stable/classes/class_displayserver.html#class-displayserver-method-window-set-mode
+func set_window_mode(mode: DisplayServer.WindowMode):
+	if mode == DisplayServer.WINDOW_MODE_FULLSCREEN:
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
+	else:
+		DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_BORDERLESS, false)
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
+
+
+func write_back_volume_setting(bus_name: String, percent: float):
+	settings.set_bus_volume_percent(bus_name, percent)
+	write_settings()
+	
+
+func write_back_display_settings(mode: DisplayServer.WindowMode):
+	settings.set_window_mode(mode)
+	write_settings()


### PR DESCRIPTION
Adding a config file that persists user settings configured in the options menu across game sessions.

Leverages a `settings.tres` resource file to persist settings values across sessions. I could have used a hand written text file, but I prefer using a Godot resource because it works nicely with the `ResourceLoader`